### PR TITLE
add parameter for time axis label

### DIFF
--- a/R/plot.fossils.R
+++ b/R/plot.fossils.R
@@ -546,7 +546,7 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
   invisible(L)
 }
 
-add.depth.profile = function(depth.profile, axis.strata, strata, show.axis, add.depth.axis, show.preferred.depth = TRUE, PD = NULL, x.labs = FALSE, t.axis.lab){
+add.depth.profile = function(depth.profile, axis.strata, strata, show.axis, add.depth.axis, show.preferred.depth = TRUE, PD = NULL, x.labs = FALSE, t.axis.lab = "Time before present"){
   par(fig = c(0,1,0,0.4), new = T)
   # change the y-axis scale for depth
   u = par("usr") # current scale

--- a/R/plot.fossils.R
+++ b/R/plot.fossils.R
@@ -41,6 +41,7 @@
 #' @param col.axis Colour of the time scale axis (default = "gray35").
 #' @param cex Numeric value giving the factor used to scale the points representing the fossils when \code{show.fossils = TRUE}.
 #' @param pch Numeric value giving the symbol used for the points representing the fossils when \code{show.fossils = TRUE}.
+#' @param t.axis.lab NULL or character. Axis label for the time (x) axis. If NULL (default), "Time before present" is used
 #' @param ... Additional parameters to be passed to \code{plot.default}.
 #'
 #' @examples
@@ -89,7 +90,7 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
                         root.edge = TRUE, hide.edge = FALSE, edge.width = 1, show.tip.label = FALSE, align.tip.label = FALSE, reconstructed = FALSE,
                         # fossil appearance
                         fossil.col = 1, range.col = rgb(0,0,1), extant.col = 1, taxa.palette = "viridis",
-                        col.axis = "gray35", cex = 1.2, pch = 18, ...) {
+                        col.axis = "gray35", cex = 1.2, pch = 18, t.axis.lab = NULL, ...) {
 
   fossils = x
 
@@ -106,6 +107,10 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
   no.margin = FALSE
   adj = NULL
   srt = 0
+
+  if (is.null(t.axis.lab)){
+    t.axis.lab = "Time before present"
+  }
 
   if(!show.tree) align.tip.label = TRUE
 
@@ -333,7 +338,7 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
       if(show.axis){
         axis(1, col = col.axis, at = axis.strata, labels = labs, lwd = 2, line = 0.5, col.axis = col.axis, cex.axis = .9)
         if(!show.proxy)
-          mtext(1, col = 'grey35', text="Time before present", line = 3, cex = 1.2)
+          mtext(1, col = 'grey35', text=t.axis.lab, line = 3, cex = 1.2)
       }
     }
 
@@ -566,7 +571,7 @@ add.depth.profile = function(depth.profile, axis.strata, strata, show.axis, add.
     lines(x = axis.strata, y = rep(PD, length(axis.strata)), col = "gray12", lwd = 2, lty = 3)
   if(show.axis){
     axis(1, col = 'grey35', at = axis.strata, labels = x.labs, lwd = 2, col.axis = 'grey35', cex.axis = .9)
-    mtext(1, col = 'grey35', text="Time before present", line = 1.5, cex = 1.2)
+    mtext(1, col = 'grey35', text=t.axis.lab , line = 1.5, cex = 1.2)
   }
   if(add.depth.axis){
     axis(2, col = 'grey35', labels = TRUE, lwd = 2, las = 2, col.axis = 'grey35', line = 0.5, cex.axis = .9)

--- a/R/plot.fossils.R
+++ b/R/plot.fossils.R
@@ -41,7 +41,7 @@
 #' @param col.axis Colour of the time scale axis (default = "gray35").
 #' @param cex Numeric value giving the factor used to scale the points representing the fossils when \code{show.fossils = TRUE}.
 #' @param pch Numeric value giving the symbol used for the points representing the fossils when \code{show.fossils = TRUE}.
-#' @param t.axis.lab NULL or character. Axis label for the time (x) axis. If NULL (default), "Time before present" is used
+#' @param t.axis.lab Axis label for the time (x) axis
 #' @param ... Additional parameters to be passed to \code{plot.default}.
 #'
 #' @examples
@@ -90,7 +90,7 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
                         root.edge = TRUE, hide.edge = FALSE, edge.width = 1, show.tip.label = FALSE, align.tip.label = FALSE, reconstructed = FALSE,
                         # fossil appearance
                         fossil.col = 1, range.col = rgb(0,0,1), extant.col = 1, taxa.palette = "viridis",
-                        col.axis = "gray35", cex = 1.2, pch = 18, t.axis.lab = NULL, ...) {
+                        col.axis = "gray35", cex = 1.2, pch = 18, t.axis.lab = "Time before present", ...) {
 
   fossils = x
 
@@ -107,10 +107,6 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
   no.margin = FALSE
   adj = NULL
   srt = 0
-
-  if (is.null(t.axis.lab)){
-    t.axis.lab = "Time before present"
-  }
 
   if(!show.tree) align.tip.label = TRUE
 
@@ -532,7 +528,8 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
     add.depth.axis = TRUE
     if(show.proxy){
       add.depth.profile(proxy.data, axis.strata, strata, show.axis, add.depth.axis,
-                        show.preferred.depth = show.preferred.environ, PD = preferred.environ, x.labs = x.labs)
+                        show.preferred.depth = show.preferred.environ, PD = preferred.environ, x.labs = x.labs,
+                        t.axis.lab = t.axis.lab)
     }
   }
 
@@ -549,7 +546,7 @@ plot.fossils = function(x, tree, show.fossils = TRUE, show.tree = TRUE, show.ran
   invisible(L)
 }
 
-add.depth.profile = function(depth.profile, axis.strata, strata, show.axis, add.depth.axis, show.preferred.depth = TRUE, PD = NULL, x.labs = FALSE){
+add.depth.profile = function(depth.profile, axis.strata, strata, show.axis, add.depth.axis, show.preferred.depth = TRUE, PD = NULL, x.labs = FALSE, t.axis.lab){
   par(fig = c(0,1,0,0.4), new = T)
   # change the y-axis scale for depth
   u = par("usr") # current scale

--- a/man/plot.fossils.Rd
+++ b/man/plot.fossils.Rd
@@ -37,6 +37,7 @@
   col.axis = "gray35",
   cex = 1.2,
   pch = 18,
+  t.axis.lab = "Time before present",
   ...
 )
 }
@@ -104,6 +105,8 @@
 \item{cex}{Numeric value giving the factor used to scale the points representing the fossils when \code{show.fossils = TRUE}.}
 
 \item{pch}{Numeric value giving the symbol used for the points representing the fossils when \code{show.fossils = TRUE}.}
+
+\item{t.axis.lab}{Axis label for the time (x) axis}
 
 \item{...}{Additional parameters to be passed to \code{plot.default}.}
 }


### PR DESCRIPTION
Added an option to manually change the x axis label in plot.fossils()
This allows for more versatility, e.g. users can specify time units. Specifically, I work with trees in both the depth domain (with units m) and the time domain (units kyr or Myr). Having the option to manually change the axis labels would clarify to the users in which domain the tree and the fossils are.